### PR TITLE
chore: Update gradle-build-action from v2 to v2.4.2

### DIFF
--- a/.github/workflows/library_java_tests.yml
+++ b/.github/workflows/library_java_tests.yml
@@ -93,19 +93,19 @@ jobs:
           java-version: 11
 
       - name: Clean for next Java
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: clean
           build-root-directory: ./${{ matrix.library }}/runtimes/java          
           
       - name: Compile Java 11
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: build
           build-root-directory: ./${{ matrix.library }}/runtimes/java
 
       - name: Test Java 11
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: runTests
           build-root-directory: ./${{ matrix.library }}/runtimes/java
@@ -117,19 +117,19 @@ jobs:
           java-version: 16
 
       - name: Clean for next Java
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: clean
           build-root-directory: ./${{ matrix.library }}/runtimes/java
 
       - name: Compile Java 16
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: build
           build-root-directory: ./${{ matrix.library }}/runtimes/java
 
       - name: Test Java 16
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: runTests
           build-root-directory: ./${{ matrix.library }}/runtimes/java     
@@ -141,19 +141,19 @@ jobs:
           java-version: 17
 
       - name: Clean for next Java
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: clean
           build-root-directory: ./${{ matrix.library }}/runtimes/java
 
       - name: Compile Java 17
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: build
           build-root-directory: ./${{ matrix.library }}/runtimes/java
 
       - name: Test Java 17
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: runTests
           build-root-directory: ./${{ matrix.library }}/runtimes/java      


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Update from v2 to v2.4.2 per security guidance: https://github.com/aws/aws-cryptographic-material-providers-library-java/security/dependabot/1

*Squash/merge commit message, if applicable:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

