### PR TITLE
fix(KMS): UserAgent

### DIFF
--- a/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "software.amazon.cryptography"
-version = "1.0.0-preview-1"
+version = "1.0.0-preview-2"
 description = "AWS Cryptographic Material Providers Library"
 
 java {

--- a/ComAmazonawsKms/src/Index.dfy
+++ b/ComAmazonawsKms/src/Index.dfy
@@ -30,8 +30,8 @@ module {:extern "software.amazon.cryptography.services.kms.internaldafny"} Com.A
 
   function method DafnyUserAgentSuffix(runtime: string): string
   {
-    var semver := "4.0.0";
-    "AwsCryptographicMPL/" + runtime + "/" + semver
+    var version := "1.0.0-preview-2";
+    "AwsCryptographicMPL/" + runtime + "/" + version
   }
 
 }


### PR DESCRIPTION
*Issue #, if available:* Fix our User Agent String

*Description of changes:*

Long term, I’d like to use a [properties file and resource](https://github.com/aws/aws-encryption-sdk-java/blob/master/src/main/resources/project.properties) to [determine the version in Java](https://github.com/aws/aws-encryption-sdk-java/blob/master/src/main/java/com/amazonaws/encryptionsdk/internal/VersionInfo.java),
as is done in the ESDK-Java.

But for now, this aligns what Dafny provides with what we have set in the build.gradle.kts.

*Squash/merge commit message, if applicable:* `fix(KMS): UserAgent`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

