### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,10 +1,10 @@
 version: 2
 updates:
   - package-ecosystem: "gradle"
-    directory: "/"
+    directory: "AwsCryptographicMaterialProviders/runtimes/java"
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directory: ".github/workflows"
     schedule:
       interval: "daily"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds gradle dependabot for the repo; because of mpl's "nesting" of dependencies some of dependabot's prs may overlap or straightup fail; however this is a good indication that we should update to stay up to date on dependency upgrades
*Squash/merge commit message, if applicable:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

