### PR TITLE
fix: Provide -compileSuffix to dafny when available

### DIFF
--- a/.github/workflows/library_java_tests.yml
+++ b/.github/workflows/library_java_tests.yml
@@ -6,6 +6,15 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    # Manual trigger for this workflow, either the normal version
+    # or the nightly build that uses the latest Dafny prerelease
+    # (accordingly to the "nightly" parameter).
+    inputs:
+      nightly:
+        description: 'Run the nightly build'
+        required: false
+        type: boolean
   schedule:
     # Nightly build against Dafny's nightly prereleases,
     # for early warning of verification issues or regressions.

--- a/.github/workflows/library_net_tests.yml
+++ b/.github/workflows/library_net_tests.yml
@@ -6,6 +6,15 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    # Manual trigger for this workflow, either the normal version
+    # or the nightly build that uses the latest Dafny prerelease
+    # (accordingly to the "nightly" parameter).
+    inputs:
+      nightly:
+        description: 'Run the nightly build'
+        required: false
+        type: boolean
   schedule:
     # Nightly build against Dafny's nightly prereleases,
     # for early warning of verification issues or regressions.

--- a/SharedMakefileV2.mk
+++ b/SharedMakefileV2.mk
@@ -45,6 +45,19 @@ LIBRARY_ROOT := $(PWD)
 # but still build everything in their local library directory.
 SMITHY_MODEL_ROOT := $(LIBRARY_ROOT)/Model
 
+# Later versions of Dafny no longer default to adding "_Compile"
+# to the names of modules when translating.
+# Our target language code still assumes it does,
+# so IF the /compileSuffix option is available in our verion of Dafny
+# we need to provide it.
+COMPILE_SUFFIX_OPTION_CHECK_EXIT_CODE := $(shell dafny /help | grep -q /compileSuffix; echo $$?)
+ifeq ($(COMPILE_SUFFIX_OPTION_CHECK_EXIT_CODE), 0)
+	COMPILE_SUFFIX_OPTION := -compileSuffix:1
+else
+	COMPILE_SUFFIX_OPTION :=
+endif
+
+
 ########################## Dafny targets
 
 # Verify the entire project
@@ -151,6 +164,7 @@ transpile_implementation:
 		-spillTargetCode:3 \
 		-compile:0 \
 		-optimizeErasableDatatypeWrapper:0 \
+		$(COMPILE_SUFFIX_OPTION) \
 		-quantifierSyntax:3 \
 		-unicodeChar:0 \
 		-functionSyntax:3 \
@@ -173,6 +187,7 @@ transpile_test:
 		-runAllTests:1 \
 		-compile:0 \
 		-optimizeErasableDatatypeWrapper:0 \
+		$(COMPILE_SUFFIX_OPTION) \
 		-quantifierSyntax:3 \
 		-unicodeChar:0 \
 		-functionSyntax:3 \


### PR DESCRIPTION
Partially fixes nightly build against Dafny prereleases (https://github.com/aws/aws-cryptographic-material-providers-library-java/actions/runs/5510616715/jobs/10045075976#step:7:723).

See https://github.com/dafny-lang/dafny/issues/4252.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

