### PR TITLE
refactor: LocalCMCTests

### DIFF
--- a/AwsCryptographicMaterialProviders/runtimes/java/src/test/LocalCMCTests.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/test/LocalCMCTests.java
@@ -1,25 +1,32 @@
-
-
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import software.amazon.cryptography.keystore.model.BeaconKeyMaterials;
-import software.amazon.cryptography.materialproviders.ICryptographicMaterialsCache;
-import software.amazon.cryptography.materialproviders.MaterialProviders;
-import software.amazon.cryptography.materialproviders.model.*;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
-import static org.testng.Assert.assertEquals;
+import Random_Compile.ExternRandom;
+
+import software.amazon.cryptography.keystore.model.BeaconKeyMaterials;
+import software.amazon.cryptography.materialproviders.ICryptographicMaterialsCache;
+import software.amazon.cryptography.materialproviders.MaterialProviders;
+import software.amazon.cryptography.materialproviders.model.CacheType;
+import software.amazon.cryptography.materialproviders.model.CreateCryptographicMaterialsCacheInput;
+import software.amazon.cryptography.materialproviders.model.DefaultCache;
+import software.amazon.cryptography.materialproviders.model.EntryDoesNotExist;
+import software.amazon.cryptography.materialproviders.model.GetCacheEntryInput;
+import software.amazon.cryptography.materialproviders.model.GetCacheEntryOutput;
+import software.amazon.cryptography.materialproviders.model.MaterialProvidersConfig;
+import software.amazon.cryptography.materialproviders.model.Materials;
+import software.amazon.cryptography.materialproviders.model.PutCacheEntryInput;
 
 
 public class LocalCMCTests {
 
-  static private ICryptographicMaterialsCache test = MaterialProviders
+  static private final ICryptographicMaterialsCache test = MaterialProviders
     .builder()
     .MaterialProvidersConfig(MaterialProvidersConfig.builder().build())
     .build()
@@ -28,7 +35,7 @@ public class LocalCMCTests {
       .cache(CacheType.builder().Default(DefaultCache.builder().entryCapacity(10).build()).build())
       .build()
     );
-  static private List<String> identifies = Arrays.asList(
+  static private final List<String> identifies = Collections.unmodifiableList(Arrays.asList(
     "one",
     "two",
     "three",
@@ -50,13 +57,13 @@ public class LocalCMCTests {
     "nineteen",
     "twenty",
     "twenty one"
-  );
-  static private Random rand = new Random();
-
+  ));
+  private static final int IDS_SIZE = identifies.size();
 
   @Test(threadPoolSize = 10, invocationCount = 300000, timeOut = 10000)
   public void TestALotOfAdding() {
-    String beaconKeyIdentifier = identifies.get(rand.nextInt(identifies.size()));
+    Random rand = ExternRandom.getSecureRandom();
+    String beaconKeyIdentifier = identifies.get(rand.nextInt(IDS_SIZE));
 
     ByteBuffer cacheIdentifier = ByteBuffer.wrap(beaconKeyIdentifier.getBytes(StandardCharsets.UTF_8));
 


### PR DESCRIPTION
*Issue #, if available:*

We are seeing sporadic test failures from `LocalCMCTests` of the nature:
```
...
Gradle suite > Gradle test > LocalCMCTests > TestALotOfAdding PASSED
Gradle suite > Gradle test > LocalCMCTests > TestALotOfAdding SKIPPED
----
Test result: SUCCESS
Test summary: 32321 tests, 32320 succeeded, 0 failed, 1 skipped
...
Execution failed for task ':test'.
> Received a completed event for test with unknown id '2.32313'. Registered test ids: '[2.2, 2.3, 2.1, :test]'
```

This could be related to issues with Gradle and TestNG:
- 2018 issue https://github.com/gradle/gradle/issues/7878
- 2023 issue https://github.com/gradle/gradle/issues/13284

However, it might also be caused by the use of non-thread safe resources in the test,
or possibly exacerbated by their use.

*Description of changes:*
- Make local resources thread local or thread safe via immutability.

*Squash/merge commit message, if applicable:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

