### PR TITLE
chore: Fix references to reusable workflows

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -13,14 +13,14 @@ on:
 
 jobs:
   push-ci-verification:
-    uses: .github/workflows/library_dafny_verification.yml
+    uses: ./.github/workflows/library_dafny_verification.yml
     with:
       dafny: ${{ inputs.dafny }}
   push-ci-java:
-    uses: .github/workflows/library_java_tests.yml
+    uses: ./.github/workflows/library_java_tests.yml
     with:
       dafny: ${{ inputs.dafny }}
   push-ci-net:
-    uses: .github/workflows/library_net_tests.yml
+    uses: ./.github/workflows/library_net_tests.yml
     with:
       dafny: ${{ inputs.dafny }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   push-ci-verification:
-    uses: .github/workflows/library_dafny_verification.yml
+    uses: ./.github/workflows/library_dafny_verification.yml
     with:
       dafny: '4.1.0'
   push-ci-java:
-    uses: .github/workflows/library_java_tests.yml
+    uses: ./.github/workflows/library_java_tests.yml
     with:
       dafny: '4.1.0'
   push-ci-net:
-    uses: .github/workflows/library_net_tests.yml
+    uses: ./.github/workflows/library_net_tests.yml
     with:
       dafny: '4.1.0'


### PR DESCRIPTION
Without the `./` GitHub thinks it’s a reference to an action implementation repository

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

