### PR TITLE
chore: Change verification strategy

### DIFF
--- a/SharedMakefileV2.mk
+++ b/SharedMakefileV2.mk
@@ -61,7 +61,7 @@ endif
 ########################## Dafny targets
 
 # Verify the entire project
-verify:
+old_verify:
 	dafny \
 		-vcsCores:$(CORES) \
 		-compile:0 \
@@ -73,6 +73,18 @@ verify:
 		-timeLimit:100 \
 		-trace \
 		`find . -name *.dfy`
+
+verify:
+	find . -name '*.dfy' | xargs -n 1 -P $(CORES) -I % dafny \
+		-compile:0 \
+		-definiteAssignment:3 \
+		-quantifierSyntax:3 \
+		-unicodeChar:0 \
+		-functionSyntax:3 \
+		-verificationLogger:csv \
+		-timeLimit:100 \
+		-trace \
+		%
 
 # Verify single file FILE with text logger.
 # This is useful for debugging resource count usage within a file.


### PR DESCRIPTION
Running all Dafny files through a single Dafny process does not scale.
This uses `xargs` to start a Dafny process per file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

