### PR TITLE
build: use gradlew

### DIFF
--- a/SharedMakefileV2.mk
+++ b/SharedMakefileV2.mk
@@ -325,7 +325,7 @@ setup_net:
 ########################## Java targets
 
 build_java: transpile_java mvn_local_deploy_dependencies
-	gradle -p runtimes/java build
+	./runtimes/java/gradlew -p runtimes/java build
 
 transpile_java: | transpile_implementation_java transpile_test_java transpile_dependencies_java
 
@@ -359,18 +359,18 @@ mvn_local_deploy_dependencies:
 
 # The Java MUST all exist already through the transpile step.
 mvn_local_deploy:
-	gradle -p runtimes/java publishMavenLocalPublicationToMavenLocal 
+	./runtimes/java/gradlew -p runtimes/java publishMavenLocalPublicationToMavenLocal 
 
 # The Java MUST all exsist if we want to publish to CodeArtifact
 mvn_ca_deploy:
-	gradle -p runtimes/java publishMavenPublicationToPublishToCodeArtifactCIRepository
+	./runtimes/java/gradlew -p runtimes/java publishMavenPublicationToPublishToCodeArtifactCIRepository
 
 mvn_staging_deploy:
-	gradle -p runtimes/java publishMavenPublicationToPublishToCodeArtifactStagingRepository
+	./runtimes/java/gradlew -p runtimes/java publishMavenPublicationToPublishToCodeArtifactStagingRepository
 
 test_java:
     # run Dafny generated tests
-	gradle -p runtimes/java runTests
+	./runtimes/java/gradlew -p runtimes/java runTests
 
 ########################## local testing targets
 


### PR DESCRIPTION
*Issue #, if available:*
I was running this on a Machine that did not have Gradle installed.
`gradlew` should work around that,
but we do not use `gradlew` in the SharedMakefile.

*Description of changes:*
Replace `gradle` with `gradlew` in the Makefiles,
removing the requirement on an installed Gradle. 

*Squash/merge commit message, if applicable:*
`build: use gradlew`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

