### PR TITLE
refactor(Java): re-enable publishToMavenLocal

### DIFF
--- a/AwsCryptographicMaterialProviders/Makefile
+++ b/AwsCryptographicMaterialProviders/Makefile
@@ -46,3 +46,11 @@ SERVICE_DEPS_AwsCryptographyKeyStore := \
 
 format_net:
 	pushd runtimes/net && dotnet format && popd
+
+maven_ca_deploy:
+	./runtimes/java/gradlew -p runtimes/java publishMavenPublicationToPublishToCodeArtifactCIRepository \
+	-PpublishedVersion="1.0.1"
+
+mvn_staging_deploy:
+	./runtimes/java/gradlew -p runtimes/java publishMavenPublicationToPublishToCodeArtifactStagingRepository \
+	-PpublishedVersion="1.0.1"

--- a/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -1,5 +1,9 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import java.net.URI
-import javax.annotation.Nullable
+
+val publishedVersion: String by project
+val verboseTesting: Boolean by project
 
 plugins {
     `java-library`
@@ -10,7 +14,7 @@ plugins {
 }
 
 group = "software.amazon.cryptography"
-version = "1.0.1"
+version = if (project.hasProperty("publishedVersion")) publishedVersion else "1.0-SNAPSHOT"
 description = "AWS Cryptographic Material Providers Library"
 
 java {
@@ -25,33 +29,9 @@ java {
     withSourcesJar()
 }
 
-var caUrl: URI? = null
-@Nullable
-val caUrlStr: String? = System.getenv("CODEARTIFACT_URL_JAVA_CONVERSION")
-if (!caUrlStr.isNullOrBlank()) {
-    caUrl = URI.create(caUrlStr)
-}
-
-var caPassword: String? = null
-@Nullable
-val caPasswordString: String? = System.getenv("CODEARTIFACT_AUTH_TOKEN")
-if (!caPasswordString.isNullOrBlank()) {
-    caPassword = caPasswordString
-}
-
 repositories {
     mavenCentral()
     mavenLocal()
-    if (caUrl != null && caPassword != null) {
-        maven {
-            name = "CodeArtifact"
-            url = caUrl!!
-            credentials {
-                username = "aws"
-                password = caPassword!!
-            }
-        }
-    }
 }
 
 dependencies {
@@ -78,20 +58,6 @@ dependencies {
 }
 
 publishing {
-    publications.create<MavenPublication>("mavenLocal") {
-        groupId = "software.amazon.cryptography"
-        artifactId = "aws-cryptographic-material-providers"
-        artifact(tasks["shadowJar"])
-        artifact(tasks["javadocJar"])
-        artifact(tasks["sourcesJar"])
-
-        // Since we ship the MPL bundled with our generated dependencies they should not be included in the generated pom.xml
-        // however; we also use additional dependencies runtime dependencies that are needed in order to properly run the mpl.
-        // When you bundle a shadow jar you don't need to include any dependencies in the pom.xml since everything is on the jar, but since
-        // we are selective so we have to "manually" write our own pom file.
-        buildPom(this )
-    }
-
     publications.create<MavenPublication>("maven") {
         groupId = "software.amazon.cryptography"
         artifactId = "aws-cryptographic-material-providers"
@@ -108,12 +74,14 @@ publishing {
 
     repositories {
         mavenLocal()
-        maven {
-            name = "PublishToCodeArtifactStaging"
-            url = URI.create("https://crypto-tools-internal-587316601012.d.codeartifact.us-east-1.amazonaws.com/maven/java-mpl-staging/")
-            credentials {
-                username = "aws"
-                password = System.getenv("CODEARTIFACT_TOKEN")
+        if (project.hasProperty("publishedVersion")) {
+            maven {
+                name = "PublishToCodeArtifactStaging"
+                url = URI.create("https://crypto-tools-internal-587316601012.d.codeartifact.us-east-1.amazonaws.com/maven/java-mpl-staging/")
+                credentials {
+                    username = "aws"
+                    password = System.getenv("CODEARTIFACT_TOKEN")
+                }
             }
         }
     }
@@ -184,23 +152,23 @@ nexusPublishing {
     }
 }
 
-signing {
-    useGpgCmd()
+if (project.hasProperty("publishedVersion")) {
+    signing {
+        useGpgCmd()
 
-    // Dynamically set these properties
-    project.ext.set("signing.gnupg.executable", "gpg")
-    project.ext.set("signing.gnupg.useLegacyGpg" , "true")
-    project.ext.set("signing.gnupg.homeDir", System.getenv("HOME") + "/.gnupg/")
-    project.ext.set("signing.gnupg.optionsFile", System.getenv("HOME") + "/.gnupg/gpg.conf")
-    project.ext.set("signing.gnupg.keyName", System.getenv("GPG_KEY"))
-    project.ext.set("signing.gnupg.passphrase", System.getenv("GPG_PASS"))
+        // Dynamically set these properties
+        project.ext.set("signing.gnupg.executable", "gpg")
+        project.ext.set("signing.gnupg.useLegacyGpg", "true")
+        project.ext.set("signing.gnupg.homeDir", System.getenv("HOME") + "/.gnupg/")
+        project.ext.set("signing.gnupg.optionsFile", System.getenv("HOME") + "/.gnupg/gpg.conf")
+        project.ext.set("signing.gnupg.keyName", System.getenv("GPG_KEY"))
+        project.ext.set("signing.gnupg.passphrase", System.getenv("GPG_PASS"))
 
-    // Signing is required if building a release version and if we're going to publish it.
-    // Otherwise if doing a maven publication we will sign
-    setRequired({
-        gradle.getTaskGraph().hasTask("publish")
-    })
-    sign(publishing.publications["maven"])
+        // Signing is required if building a release version and if we're going to publish it.
+        // Otherwise if doing a maven publication we will sign
+        setRequired({ gradle.getTaskGraph().hasTask("publish") })
+        sign(publishing.publications["maven"])
+    }
 }
 
 fun SourceDirectorySet.mainSourceSet() {
@@ -216,9 +184,13 @@ tasks.test {
     // This will show System.out.println statements
     testLogging.showStandardStreams = true
 
+    var whatToLog = mutableSetOf(org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED, org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED)
+    if (project.hasProperty("verboseTesting")) {
+        whatToLog = mutableSetOf(org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED, org.gradle.api.tasks.testing.logging.TestLogEvent.PASSED, org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED)
+    }
     testLogging {
         lifecycle {
-            events = mutableSetOf(org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED, org.gradle.api.tasks.testing.logging.TestLogEvent.PASSED, org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED)
+            events = whatToLog
             exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
             showExceptions = true
             showCauses = true

--- a/AwsCryptographyPrimitives/runtimes/java/build.gradle.kts
+++ b/AwsCryptographyPrimitives/runtimes/java/build.gradle.kts
@@ -1,5 +1,5 @@
-import java.net.URI
-import javax.annotation.Nullable
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 plugins {
     `java-library`
@@ -22,33 +22,9 @@ java {
     }
 }
 
-var caUrl: URI? = null
-@Nullable
-val caUrlStr: String? = System.getenv("CODEARTIFACT_URL_JAVA_CONVERSION")
-if (!caUrlStr.isNullOrBlank()) {
-    caUrl = URI.create(caUrlStr)
-}
-
-var caPassword: String? = null
-@Nullable
-val caPasswordString: String? = System.getenv("CODEARTIFACT_AUTH_TOKEN")
-if (!caPasswordString.isNullOrBlank()) {
-    caPassword = caPasswordString
-}
-
 repositories {
     mavenCentral()
     mavenLocal()
-    if (caUrl != null && caPassword != null) {
-        maven {
-            name = "CodeArtifact"
-            url = caUrl!!
-            credentials {
-                username = "aws"
-                password = caPassword!!
-            }
-        }
-    }
 }
 
 dependencies {
@@ -59,11 +35,6 @@ dependencies {
 }
 
 publishing {
-    publications.create<MavenPublication>("mavenLocal") {
-        groupId = "software.amazon.cryptography"
-        artifactId = "AwsCryptographyPrimitives"
-        from(components["java"])
-    }
     publications.create<MavenPublication>("maven") {
         groupId = "software.amazon.cryptography"
         artifactId = "AwsCryptographyPrimitives"

--- a/ComAmazonawsDynamodb/runtimes/java/build.gradle.kts
+++ b/ComAmazonawsDynamodb/runtimes/java/build.gradle.kts
@@ -1,5 +1,5 @@
-import java.net.URI
-import javax.annotation.Nullable
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 plugins {
     `java-library`
@@ -9,20 +9,6 @@ plugins {
 group = "software.amazon.cryptography"
 version = "1.0-SNAPSHOT"
 description = "ComAmazonawsDynamodb"
-
-var caUrl: URI? = null
-@Nullable
-val caUrlStr: String? = System.getenv("CODEARTIFACT_URL_JAVA_CONVERSION")
-if (!caUrlStr.isNullOrBlank()) {
-    caUrl = URI.create(caUrlStr)
-}
-
-var caPassword: String? = null
-@Nullable
-val caPasswordString: String? = System.getenv("CODEARTIFACT_AUTH_TOKEN")
-if (!caPasswordString.isNullOrBlank()) {
-    caPassword = caPasswordString
-}
 
 java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(8))
@@ -39,16 +25,6 @@ java {
 repositories {
     mavenCentral()
     mavenLocal()
-        if (caUrl != null && caPassword != null) {
-        maven {
-            name = "CodeArtifact"
-            url = caUrl!!
-            credentials {
-                username = "aws"
-                password = caPassword!!
-            }
-        }
-    }
 }
 
 dependencies {
@@ -60,11 +36,6 @@ dependencies {
 }
 
 publishing {
-    publications.create<MavenPublication>("mavenLocal") {
-        groupId = "software.amazon.cryptography"
-        artifactId = "ComAmazonawsDynamodb"
-        from(components["java"])
-    }
     publications.create<MavenPublication>("maven") {
         groupId = "software.amazon.cryptography"
         artifactId = "ComAmazonawsDynamodb"

--- a/ComAmazonawsKms/runtimes/java/build.gradle.kts
+++ b/ComAmazonawsKms/runtimes/java/build.gradle.kts
@@ -1,5 +1,5 @@
-import java.net.URI
-import javax.annotation.Nullable
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 plugins {
     `java-library`
@@ -22,33 +22,9 @@ java {
     }
 }
 
-var caUrl: URI? = null
-@Nullable
-val caUrlStr: String? = System.getenv("CODEARTIFACT_URL_JAVA_CONVERSION")
-if (!caUrlStr.isNullOrBlank()) {
-    caUrl = URI.create(caUrlStr)
-}
-
-var caPassword: String? = null
-@Nullable
-val caPasswordString: String? = System.getenv("CODEARTIFACT_AUTH_TOKEN")
-if (!caPasswordString.isNullOrBlank()) {
-    caPassword = caPasswordString
-}
-
 repositories {
     mavenCentral()
     mavenLocal()
-    if (caUrl != null && caPassword != null) {
-        maven {
-            name = "CodeArtifact"
-            url = caUrl!!
-            credentials {
-                username = "aws"
-                password = caPassword!!
-            }
-        }
-    }
 }
 
 dependencies {
@@ -60,11 +36,6 @@ dependencies {
 }
 
 publishing {
-    publications.create<MavenPublication>("mavenLocal") {
-        groupId = "software.amazon.cryptography"
-        artifactId = "ComAmazonawsKms"
-        from(components["java"])
-    }
     publications.create<MavenPublication>("maven") {
         groupId = "software.amazon.cryptography"
         artifactId = "ComAmazonawsKms"

--- a/SharedMakefileV2.mk
+++ b/SharedMakefileV2.mk
@@ -359,7 +359,7 @@ mvn_local_deploy_dependencies:
 
 # The Java MUST all exist already through the transpile step.
 mvn_local_deploy:
-	./runtimes/java/gradlew -p runtimes/java publishMavenLocalPublicationToMavenLocal 
+	./runtimes/java/gradlew -p runtimes/java publishMavenPublicationToMavenLocal
 
 # The Java MUST all exsist if we want to publish to CodeArtifact
 mvn_ca_deploy:

--- a/StandardLibrary/runtimes/java/build.gradle.kts
+++ b/StandardLibrary/runtimes/java/build.gradle.kts
@@ -1,5 +1,5 @@
-import java.net.URI
-import javax.annotation.Nullable
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 plugins {
     `java-library`
@@ -21,33 +21,9 @@ java {
     }
 }
 
-var caUrl: URI? = null
-@Nullable
-val caUrlStr: String? = System.getenv("CODEARTIFACT_URL_JAVA_CONVERSION")
-if (!caUrlStr.isNullOrBlank()) {
-    caUrl = URI.create(caUrlStr)
-}
-
-var caPassword: String? = null
-@Nullable
-val caPasswordString: String? = System.getenv("CODEARTIFACT_AUTH_TOKEN")
-if (!caPasswordString.isNullOrBlank()) {
-    caPassword = caPasswordString
-}
-
 repositories {
     mavenCentral()
     mavenLocal()
-    if (caUrl != null && caPassword != null) {
-        maven {
-            name = "CodeArtifact"
-            url = caUrl!!
-            credentials {
-                username = "aws"
-                password = caPassword!!
-            }
-        }
-    }
 }
 
 dependencies {
@@ -55,11 +31,6 @@ dependencies {
     implementation("software.amazon.smithy.dafny:conversion:0.1")
 }
 publishing {
-    publications.create<MavenPublication>("mavenLocal") {
-        groupId = "software.amazon.cryptography"
-        artifactId = "StandardLibrary"
-        from(components["java"])
-    }
     publications.create<MavenPublication>("maven") {
         groupId = "software.amazon.cryptography"
         artifactId = "StandardLibrary"

--- a/TestVectorsAwsCryptographicMaterialProviders/Makefile
+++ b/TestVectorsAwsCryptographicMaterialProviders/Makefile
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 CORES=2
+PUBLISHED_VERSION="1.0-SNAPSHOT"
 
 include ../SharedMakefileV2.mk
 
@@ -58,3 +59,6 @@ SERVICE_DEPS_KeyVectors := \
 
 format_net:
 	pushd runtimes/net && dotnet format && popd
+
+test_java:
+	./runtimes/java/gradlew -p runtimes/java runTests -PpublishedVersion=$(PUBLISHED_VERSION)

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -1,9 +1,9 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 import java.net.URI
 import javax.annotation.Nullable
 
-tasks.wrapper {
-    gradleVersion = "7.6"
-}
+val publishedVersion: String by project
 
 plugins {
     `java-library`
@@ -58,7 +58,8 @@ repositories {
 dependencies {
     implementation("org.dafny:DafnyRuntime:4.1.0")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
-    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.0.1")
+    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:${
+        if (project.hasProperty("publishedVersion")) publishedVersion else "1.0-SNAPSHOT"}")
     implementation(platform("software.amazon.awssdk:bom:2.19.1"))
     implementation("software.amazon.awssdk:dynamodb")
     implementation("software.amazon.awssdk:dynamodb-enhanced")
@@ -67,11 +68,6 @@ dependencies {
 }
 
 publishing {
-    publications.create<MavenPublication>("mavenLocal") {
-        groupId = group as String?
-        artifactId = description
-        from(components["java"])
-    }
     publications.create<MavenPublication>("maven") {
         groupId = group as String?
         artifactId = description
@@ -93,4 +89,8 @@ tasks.register<JavaExec>("runTests") {
 tasks.register<Copy>("copyKeysJSON") {
     from(layout.projectDirectory.file("../../dafny/TestVectorsAwsCryptographicMaterialProviders/test/keys.json"))
     into(layout.projectDirectory.dir("dafny/TestVectorsAwsCryptographicMaterialProviders/test"))
+}
+
+tasks.wrapper {
+    gradleVersion = "7.6"
 }

--- a/codebuild/release/release-prod.yml
+++ b/codebuild/release/release-prod.yml
@@ -6,6 +6,7 @@ version: 0.2
 env:
   variables:
     BRANCH: "main"
+    VERSION: "1.0.1"
   parameter-store:
     ACCOUNT: /CodeBuild/AccountId
   secrets-manager:
@@ -58,7 +59,7 @@ phases:
       # transpile the code only for this project
       - make transpile_implementation_java
       - make transpile_test_java
-      - make test_java
+      - make PUBLISHED_VERSION=$VERSION test_java
       - cd ../AwsCryptographicMaterialProviders/
 
       # Publish to Sonatype

--- a/codebuild/release/validate-release.yml
+++ b/codebuild/release/validate-release.yml
@@ -8,6 +8,7 @@ env:
     REGION: us-east-1
     DOMAIN: crypto-tools-internal
     REPOSITORY: java-mpl-staging
+    VERSION: "1.0.1"
   parameter-store:
     ACCOUNT: /CodeBuild/AccountId
 
@@ -46,4 +47,4 @@ phases:
       # transpile the code only for this project
       - make transpile_implementation_java
       - make transpile_test_java
-      - make test_java
+      - make PUBLISHED_VERSION=$VERSION test_java

--- a/codebuild/staging/release-staging.yml
+++ b/codebuild/staging/release-staging.yml
@@ -8,6 +8,7 @@ env:
     REGION: us-east-1
     DOMAIN: crypto-tools-internal
     REPOSITORY: java-mpl-staging
+    VERSION: "1.0.1"
   parameter-store:
     ACCOUNT: /CodeBuild/AccountId
   secrets-manager:
@@ -56,7 +57,7 @@ phases:
       # transpile the code only for this project
       - make transpile_implementation_java
       - make transpile_test_java
-      - make test_java
+      - make PUBLISHED_VERSION=$VERSION test_java
       - cd ../AwsCryptographicMaterialProviders/
       # Deploy to AWS CodeArtifact
       - make mvn_staging_deploy

--- a/codebuild/staging/validate-staging.yml
+++ b/codebuild/staging/validate-staging.yml
@@ -8,6 +8,7 @@ env:
     REGION: us-east-1
     DOMAIN: crypto-tools-internal
     REPOSITORY: java-mpl-staging
+    VERSION: "1.0.1"
   parameter-store:
     ACCOUNT: /CodeBuild/AccountId
 
@@ -44,4 +45,4 @@ phases:
       # transpile the code only for this project
       - make transpile_implementation_java
       - make transpile_test_java
-      - make test_java
+      - make PUBLISHED_VERSION=$VERSION test_java


### PR DESCRIPTION
*Issue #, if available:* Unable to locally test due to:
1. Publishing conflicts b/w `maven` and `mavenLocal` 
2. Configuration of the Signing Job always triggered
3. Test Vectors depended on `1.0.1` instead of `SNAPSHOT`
4. MPL would not publish a SNAPSHOT, but was fixed on publish `1.0.1`

*Description of changes:*
1. For every `build.gradle.kts`, 
other than the Test Vectors, 
remove the CA Repository from the pull list.
We are not using this anymore, and I don't want un-used code. 

2. Resolve the publication conflict by removing the `mavenLocal` publication.
`mavenLocal` is identical to `maven`.
The only difference was it would not be Signed.
BUT, since the two publications were identical, 
Gradle decided to overwrite one with the other,
and would ALWAYS try and Sign,
even when we were just trying to publish to local for testing.

3. In the MPL, disable, by default, positive test logging.
Ryan really wanted positive test logging.
But now we have the multi-threading tests,
which produce a useless amount of logging.
So I disabled that.

4. 

*Squash/merge commit message, if applicable:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

