### PR TITLE
chore(deps): bump Dafny 4.2.0

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -11,14 +11,14 @@ jobs:
     if: github.event_name != 'schedule' || github.repository_owner == 'aws'
     uses: ./.github/workflows/library_dafny_verification.yml
     with:
-      dafny: '4.1.0'
+      dafny: '4.2.0'
   daily-ci-java:
     if: github.event_name != 'schedule' || github.repository_owner == 'aws'
     uses: ./.github/workflows/library_java_tests.yml
     with:
-      dafny: '4.1.0'
+      dafny: '4.2.0'
   daily-ci-net:
     if: github.event_name != 'schedule' || github.repository_owner == 'aws'
     uses: ./.github/workflows/library_net_tests.yml
     with:
-      dafny: '4.1.0'
+      dafny: '4.2.0'

--- a/.github/workflows/library_java_tests.yml
+++ b/.github/workflows/library_java_tests.yml
@@ -23,7 +23,7 @@ jobs:
         ]
         os: [
           # TODO just test on mac for now
-          windows-latest,
+          # windows-latest,
           ubuntu-latest,
           macos-latest
         ]

--- a/.github/workflows/library_java_tests.yml
+++ b/.github/workflows/library_java_tests.yml
@@ -32,6 +32,9 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Support longpaths on Git checkout
+        run: |
+          git config --global core.longpaths true
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/library_java_tests.yml
+++ b/.github/workflows/library_java_tests.yml
@@ -23,8 +23,8 @@ jobs:
         ]
         os: [
           # TODO just test on mac for now
-          #windows-latest,
-          #ubuntu-latest,
+          windows-latest,
+          ubuntu-latest,
           macos-latest
         ]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/library_java_tests.yml
+++ b/.github/workflows/library_java_tests.yml
@@ -23,7 +23,7 @@ jobs:
         ]
         os: [
           # TODO just test on mac for now
-          # windows-latest,
+          windows-latest,
           ubuntu-latest,
           macos-latest
         ]

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -8,12 +8,12 @@ jobs:
   pr-ci-verification:
     uses: ./.github/workflows/library_dafny_verification.yml
     with:
-      dafny: '4.1.0'
+      dafny: '4.2.0'
   pr-ci-java:
     uses: ./.github/workflows/library_java_tests.yml
     with:
-      dafny: '4.1.0'
+      dafny: '4.2.0'
   pr-ci-net:
     uses: ./.github/workflows/library_net_tests.yml
     with:
-      dafny: '4.1.0'
+      dafny: '4.2.0'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,12 +10,12 @@ jobs:
   push-ci-verification:
     uses: ./.github/workflows/library_dafny_verification.yml
     with:
-      dafny: '4.1.0'
+      dafny: '4.2.0'
   push-ci-java:
     uses: ./.github/workflows/library_java_tests.yml
     with:
-      dafny: '4.1.0'
+      dafny: '4.2.0'
   push-ci-net:
     uses: ./.github/workflows/library_net_tests.yml
     with:
-      dafny: '4.1.0'
+      dafny: '4.2.0'

--- a/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     implementation("software.amazon.cryptography:ComAmazonawsDynamodb:1.0-SNAPSHOT")
 
     // Dafny dependencies
-    implementation("org.dafny:DafnyRuntime:4.1.0")
+    implementation("org.dafny:DafnyRuntime:4.2.0")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
 
     // sdk dependencies

--- a/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
+++ b/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="AWSSDK.Core" Version="3.7.103" />
-        <PackageReference Include="DafnyRuntime" Version="4.0.0.50303" />
+        <PackageReference Include="DafnyRuntime" Version="4.2.0" />
         <PackageReference Include="Portable.BouncyCastle" Version="1.8.5.2" />
         <!--
           System.Collections.Immutable can be removed once dafny.msbuild is updated with

--- a/AwsCryptographyPrimitives/runtimes/java/build.gradle.kts
+++ b/AwsCryptographyPrimitives/runtimes/java/build.gradle.kts
@@ -52,7 +52,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:4.1.0")
+    implementation("org.dafny:DafnyRuntime:4.2.0")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
     implementation("software.amazon.cryptography:StandardLibrary:1.0-SNAPSHOT")
     implementation("org.bouncycastle:bcprov-jdk18on:1.72")

--- a/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
+++ b/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.Core" Version="3.7.12.2" />
-    <PackageReference Include="DafnyRuntime" Version="4.0.0.50303" />
+    <PackageReference Include="DafnyRuntime" Version="4.2.0" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.5.2" />
     <!--
       System.Collections.Immutable can be removed once dafny.msbuild is updated with

--- a/ComAmazonawsDynamodb/runtimes/java/build.gradle.kts
+++ b/ComAmazonawsDynamodb/runtimes/java/build.gradle.kts
@@ -52,7 +52,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:4.1.0")
+    implementation("org.dafny:DafnyRuntime:4.2.0")
     implementation("software.amazon.cryptography:StandardLibrary:1.0-SNAPSHOT")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
     implementation(platform("software.amazon.awssdk:bom:2.19.1"))

--- a/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
+++ b/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DafnyRuntime" Version="4.0.0.50303" />
+    <PackageReference Include="DafnyRuntime" Version="4.2.0" />
     <PackageReference Include="AWSSDK.Core" Version="3.7.103" />
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.8" />
     <!--

--- a/ComAmazonawsKms/runtimes/java/build.gradle.kts
+++ b/ComAmazonawsKms/runtimes/java/build.gradle.kts
@@ -52,7 +52,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:4.1.0")
+    implementation("org.dafny:DafnyRuntime:4.2.0")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
     implementation("software.amazon.cryptography:StandardLibrary:1.0-SNAPSHOT")
     implementation(platform("software.amazon.awssdk:bom:2.19.1"))

--- a/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
+++ b/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DafnyRuntime" Version="4.0.0.50303" />
+    <PackageReference Include="DafnyRuntime" Version="4.2.0" />
     <PackageReference Include="AWSSDK.Core" Version="3.7.11.12" />
     <PackageReference Include="AWSSDK.KeyManagementService" Version="3.7.3.20" />
     <!--

--- a/SharedMakefileV2.mk
+++ b/SharedMakefileV2.mk
@@ -50,13 +50,16 @@ SMITHY_MODEL_ROOT := $(LIBRARY_ROOT)/Model
 # Our target language code still assumes it does,
 # so IF the /compileSuffix option is available in our verion of Dafny
 # we need to provide it.
-COMPILE_SUFFIX_OPTION_CHECK_EXIT_CODE := $(shell dafny /help | grep -q /compileSuffix; echo $$?)
-ifeq ($(COMPILE_SUFFIX_OPTION_CHECK_EXIT_CODE), 0)
-	COMPILE_SUFFIX_OPTION := -compileSuffix:1
-else
-	COMPILE_SUFFIX_OPTION := -compileSuffix:1
-endif
-
+# on 4.2.0 running on windows this shell command fails; we should fix this so the right
+# thing happens on the right environment
+# COMPILE_SUFFIX_OPTION_CHECK_EXIT_CODE := $(shell dafny /help | grep -q /compileSuffix; echo $$?)
+# ifeq ($(COMPILE_SUFFIX_OPTION_CHECK_EXIT_CODE), 0)
+# 	COMPILE_SUFFIX_OPTION := -compileSuffix:1
+# else
+# 	COMPILE_SUFFIX_OPTION := -compileSuffix:1
+# endif
+# for now we know this will work across the three environmnets we test in (windows, macos, ubuntu)
+COMPILE_SUFFIX_OPTION := -compileSuffix:1
 
 ########################## Dafny targets
 

--- a/SharedMakefileV2.mk
+++ b/SharedMakefileV2.mk
@@ -54,7 +54,7 @@ COMPILE_SUFFIX_OPTION_CHECK_EXIT_CODE := $(shell dafny /help | grep -q /compileS
 ifeq ($(COMPILE_SUFFIX_OPTION_CHECK_EXIT_CODE), 0)
 	COMPILE_SUFFIX_OPTION := -compileSuffix:1
 else
-	COMPILE_SUFFIX_OPTION :=
+	COMPILE_SUFFIX_OPTION := -compileSuffix:1
 endif
 
 

--- a/SharedMakefileV2.mk
+++ b/SharedMakefileV2.mk
@@ -359,18 +359,18 @@ mvn_local_deploy_dependencies:
 
 # The Java MUST all exist already through the transpile step.
 mvn_local_deploy:
-	./runtimes/java/gradlew -p runtimes/java publishMavenLocalPublicationToMavenLocal 
+	runtimes/java/gradlew -p runtimes/java publishMavenLocalPublicationToMavenLocal 
 
 # The Java MUST all exsist if we want to publish to CodeArtifact
 mvn_ca_deploy:
-	./runtimes/java/gradlew -p runtimes/java publishMavenPublicationToPublishToCodeArtifactCIRepository
+	runtimes/java/gradlew -p runtimes/java publishMavenPublicationToPublishToCodeArtifactCIRepository
 
 mvn_staging_deploy:
-	./runtimes/java/gradlew -p runtimes/java publishMavenPublicationToPublishToCodeArtifactStagingRepository
+	runtimes/java/gradlew -p runtimes/java publishMavenPublicationToPublishToCodeArtifactStagingRepository
 
 test_java:
     # run Dafny generated tests
-	./runtimes/java/gradlew -p runtimes/java runTests
+	runtimes/java/gradlew -p runtimes/java runTests
 
 ########################## local testing targets
 

--- a/SharedMakefileV2.mk
+++ b/SharedMakefileV2.mk
@@ -325,7 +325,7 @@ setup_net:
 ########################## Java targets
 
 build_java: transpile_java mvn_local_deploy_dependencies
-	./runtimes/java/gradlew -p runtimes/java build
+	runtimes/java/gradlew -p runtimes/java build
 
 transpile_java: | transpile_implementation_java transpile_test_java transpile_dependencies_java
 

--- a/SharedMakefileV2.mk
+++ b/SharedMakefileV2.mk
@@ -325,7 +325,7 @@ setup_net:
 ########################## Java targets
 
 build_java: transpile_java mvn_local_deploy_dependencies
-	runtimes/java/gradlew -p runtimes/java build
+	./runtimes/java/gradlew -p runtimes/java build
 
 transpile_java: | transpile_implementation_java transpile_test_java transpile_dependencies_java
 
@@ -359,18 +359,18 @@ mvn_local_deploy_dependencies:
 
 # The Java MUST all exist already through the transpile step.
 mvn_local_deploy:
-	runtimes/java/gradlew -p runtimes/java publishMavenLocalPublicationToMavenLocal 
+	./runtimes/java/gradlew -p runtimes/java publishMavenLocalPublicationToMavenLocal 
 
 # The Java MUST all exsist if we want to publish to CodeArtifact
 mvn_ca_deploy:
-	runtimes/java/gradlew -p runtimes/java publishMavenPublicationToPublishToCodeArtifactCIRepository
+	./runtimes/java/gradlew -p runtimes/java publishMavenPublicationToPublishToCodeArtifactCIRepository
 
 mvn_staging_deploy:
-	runtimes/java/gradlew -p runtimes/java publishMavenPublicationToPublishToCodeArtifactStagingRepository
+	./runtimes/java/gradlew -p runtimes/java publishMavenPublicationToPublishToCodeArtifactStagingRepository
 
 test_java:
     # run Dafny generated tests
-	runtimes/java/gradlew -p runtimes/java runTests
+	./runtimes/java/gradlew -p runtimes/java runTests
 
 ########################## local testing targets
 

--- a/StandardLibrary/runtimes/java/build.gradle.kts
+++ b/StandardLibrary/runtimes/java/build.gradle.kts
@@ -51,7 +51,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:4.1.0")
+    implementation("org.dafny:DafnyRuntime:4.2.0")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
 }
 publishing {

--- a/StandardLibrary/runtimes/net/STD.csproj
+++ b/StandardLibrary/runtimes/net/STD.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DafnyRuntime" Version="4.0.0.50303" />
+    <PackageReference Include="DafnyRuntime" Version="4.2.0" />
     <!--
       System.Collections.Immutable can be removed once dafny.msbuild is updated with
       https://github.com/dafny-lang/dafny.msbuild/pull/10 and versioned

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -56,7 +56,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:4.1.0")
+    implementation("org.dafny:DafnyRuntime:4.2.0")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
     implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.0.1")
     implementation(platform("software.amazon.awssdk:bom:2.19.1"))

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/net/TestVectors.csproj
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/net/TestVectors.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DafnyRuntime" Version="4.0.0.50303" />
+        <PackageReference Include="DafnyRuntime" Version="4.2.0" />
         <!--
           System.Collections.Immutable can be removed once dafny.msbuild is updated with
           https://github.com/dafny-lang/dafny.msbuild/pull/10 and versioned


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Updates projects to verify on Dafny 4.2.0 and build on Dafny 4.2.0 runtime for Java and .NET
- Update the SharedMakefileV2 to include `-compileSuffix:1` flag on all builds in order to correctly build .NET in windows environments.

**NOTE**: This PR does not enable java testing on windows; gradle works differently on windows and should be addressed on a separate PR.

*Squash/merge commit message, if applicable:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

