### PR TITLE
fix: fix typo in encryption materials validation

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/KeyWrapping/EdkWrapping.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/KeyWrapping/EdkWrapping.dfy
@@ -170,7 +170,7 @@ module EdkWrapping {
   {
     :- Need(Materials.ValidEncryptionMaterials(encryptionMaterials),
             Types.AwsCryptographicMaterialProvidersException(
-              message := "Invalid materials for decryption."));
+              message := "Invalid materials for encryption."));
 
     if (encryptionMaterials.plaintextDataKey.Some? &&
         encryptionMaterials.algorithmSuite.edkWrapping.DIRECT_KEY_WRAPPING?)  {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-cryptographic-material-providers-library-java/issues/144

*Description of changes:* Fixes the error message, the validation for encryption materials happens during encryption (`OnEncrypt`) and so the error message MUST refer to (invalid) _encryption_ materials. 

*Squash/merge commit message, if applicable:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

