### PR TITLE
chore(Java): resolve `awssdk:core` dependency in TestVectors build.gradle.kts

### DIFF
--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -63,7 +63,6 @@ dependencies {
     implementation("software.amazon.awssdk:dynamodb")
     implementation("software.amazon.awssdk:dynamodb-enhanced")
     implementation("software.amazon.awssdk:kms")
-    implementation("software.amazon.awssdk:core:2.19.1")
 }
 
 publishing {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Remove `software.amazon.awssdk:core:2.19.1` dependency from TestVectors `build.gradle` to sync with `AwsCryptographicMaterialProviders` `build.gradle`. 
- The above dependency prevents the ESDK-Java `pom.xml` from pulling MPL TestVector.

*Squash/merge commit message, if applicable:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

